### PR TITLE
fix: Auto-import predefined module for drop-in compatibility

### DIFF
--- a/src/crcmod/__init__.py
+++ b/src/crcmod/__init__.py
@@ -15,5 +15,6 @@ all you need is a function for CRC calculation.
 
 from .crcmod import Crc, mkCrcFun
 from ._version import __version__
+from . import predefined  # Auto-import for drop-in compatibility with original crcmod
 
-__all__ = ("Crc", "mkCrcFun", "__version__")
+__all__ = ("Crc", "mkCrcFun", "__version__", "predefined")


### PR DESCRIPTION
Add automatic import of predefined submodule in __init__.py to match the behavior of the original crcmod package. This allows code using `import crcmod` followed by `crcmod.predefined.Crc()` to work without requiring explicit `import crcmod.predefined`.

This makes crcmod-plus truly a drop-in replacement for crcmod.