### PR TITLE
Use standard collection types and TypedDict

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ a model for the new version.
 
 ### Python version
 
-This package supports Python 3.7 and newer.
+This package supports Python 3.9 and newer.
 
 ### Building C extension
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,12 @@ dev = ["pytest"]
 [tool.cibuildwheel]
 enable = ["cpython-freethreading", "pypy"]
 
+[tool.ruff]
+target-version = "py39"
+
+[tool.ruff.lint]
+extend-select = ["UP035"]
+
 [tool.ruff.lint.extend-per-file-ignores]
 "predefined.py" = ["E501"]
 

--- a/src/crcmod/_crcfunpy.py
+++ b/src/crcmod/_crcfunpy.py
@@ -26,7 +26,7 @@
 # SOFTWARE.
 # -----------------------------------------------------------------------------
 
-from typing import Sequence
+from collections.abc import Sequence
 
 from .types import Buffer
 

--- a/src/crcmod/crcmod.py
+++ b/src/crcmod/crcmod.py
@@ -37,7 +37,8 @@ except ImportError:
 
 import struct
 
-from typing import Dict, IO, List, Optional, Sequence, Tuple
+from typing import IO, Optional
+from collections.abc import Sequence
 
 from .types import Buffer, CrcFun, CrcFunNoDefaultArgs
 
@@ -88,7 +89,7 @@ class Crc:
     crcValue: int
 
     _crc: CrcFun
-    table: List[int]
+    table: list[int]
 
     def __init__(
         self,
@@ -118,7 +119,7 @@ class Crc:
         self.crcValue = self.initCrc
 
     def __str__(self) -> str:
-        lst: List[str] = []
+        lst: list[str] = []
         lst.append("poly = 0x%X" % self.poly)
         lst.append("reverse = %s" % self.reverse)
         fmt = "0x%%0%dX" % (self.digest_size * 2)
@@ -168,7 +169,7 @@ class Crc:
         """
         n = self.digest_size
         crc = self.crcValue
-        lst: List[int] = []
+        lst: list[int] = []
         while n > 0:
             lst.append(crc & 0xFF)
             crc = crc >> 8
@@ -182,7 +183,7 @@ class Crc:
         """
         n = self.digest_size
         crc = self.crcValue
-        lst: List[str] = []
+        lst: list[str] = []
         while n > 0:
             lst.append("%02X" % (crc & 0xFF))
             crc = crc >> 8
@@ -243,7 +244,7 @@ class Crc:
         # Select the number of entries per row in the output code.
         n = {1: 8, 2: 8, 3: 4, 4: 4, 8: 2}[self.digest_size]
 
-        lst: List[str] = []
+        lst: list[str] = []
         for i, val in enumerate(self.table):
             if (i % n) == 0:
                 lst.append("\n    ")
@@ -279,7 +280,7 @@ class Crc:
             "preCondition": preCondition,
             "postCondition": postCondition,
         }
-        out.write(_codeTemplate % parms)
+        _ = out.write(_codeTemplate % parms)
 
 
 # -----------------------------------------------------------------------------
@@ -341,7 +342,7 @@ def _bitrev(x: int, n: int) -> int:
 
 def _bytecrc(crc: int, poly: int, n: int) -> int:
     mask = 1 << (n - 1)
-    for i in range(8):
+    for _ in range(8):
         if crc & mask:
             crc = (crc << 1) ^ poly
         else:
@@ -352,7 +353,7 @@ def _bytecrc(crc: int, poly: int, n: int) -> int:
 
 
 def _bytecrc_r(crc: int, poly: int, n: int) -> int:
-    for i in range(8):
+    for _ in range(8):
         if crc & 1:
             crc = (crc >> 1) ^ poly
         else:
@@ -371,14 +372,14 @@ def _bytecrc_r(crc: int, poly: int, n: int) -> int:
 # have been checked for validity by the caller.
 
 
-def _mkTable(poly: int, n: int) -> List[int]:
+def _mkTable(poly: int, n: int) -> list[int]:
     mask = (1 << n) - 1
     poly = poly & mask
     table = [_bytecrc(i << (n - 8), poly, n) for i in range(256)]
     return table
 
 
-def _mkTable_r(poly: int, n: int) -> List[int]:
+def _mkTable_r(poly: int, n: int) -> list[int]:
     mask = (1 << n) - 1
     poly = _bitrev(poly & mask, n)
     table = [_bytecrc_r(i, poly, n) for i in range(256)]
@@ -388,7 +389,7 @@ def _mkTable_r(poly: int, n: int) -> List[int]:
 # -----------------------------------------------------------------------------
 # Map the CRC size onto the functions that handle these sizes.
 
-_sizeMap: Dict[int, Tuple[CrcFunNoDefaultArgs, CrcFunNoDefaultArgs]] = {
+_sizeMap: dict[int, tuple[CrcFunNoDefaultArgs, CrcFunNoDefaultArgs]] = {
     8: (_crcfun._crc8, _crcfun._crc8r),
     16: (_crcfun._crc16, _crcfun._crc16r),
     24: (_crcfun._crc24, _crcfun._crc24r),
@@ -402,7 +403,7 @@ _sizeMap: Dict[int, Tuple[CrcFunNoDefaultArgs, CrcFunNoDefaultArgs]] = {
 # code to use for the platform we are running on.  This should properly adapt
 # to 32 and 64 bit machines.
 
-_sizeToTypeCode: Dict[int, str] = {}
+_sizeToTypeCode: dict[int, str] = {}
 
 for typeCode in "B H I L Q".split():
     size = {1: 8, 2: 16, 4: 32, 8: 64}.get(struct.calcsize(typeCode), None)
@@ -419,7 +420,7 @@ del typeCode, size  # type: ignore
 # It returns the size of the CRC (in bits), and "sanitized" initial/final XOR values.
 
 
-def _verifyParams(poly: int, initCrc: int, xorOut: int) -> Tuple[int, int, int]:
+def _verifyParams(poly: int, initCrc: int, xorOut: int) -> tuple[int, int, int]:
     sizeBits = _verifyPoly(poly)
 
     mask = (1 << sizeBits) - 1
@@ -448,17 +449,17 @@ def _verifyParams(poly: int, initCrc: int, xorOut: int) -> Tuple[int, int, int]:
 
 def _mkCrcFun(
     poly: int, sizeBits: int, initCrc: int, rev: bool, xorOut: int
-) -> Tuple[CrcFun, List[int]]:
+) -> tuple[CrcFun, list[int]]:
     if rev:
-        tableList = _mkTable_r(poly, sizeBits)
+        tablelist = _mkTable_r(poly, sizeBits)
         _fun = _sizeMap[sizeBits][1]
     else:
-        tableList = _mkTable(poly, sizeBits)
+        tablelist = _mkTable(poly, sizeBits)
         _fun = _sizeMap[sizeBits][0]
 
-    _table: Sequence[int] = tableList
+    _table: Sequence[int] = tablelist
     if _usingExtension:
-        _table = struct.pack(_sizeToTypeCode[sizeBits], *tableList)
+        _table = struct.pack(_sizeToTypeCode[sizeBits], *tablelist)
 
     if xorOut == 0:
 
@@ -480,7 +481,7 @@ def _mkCrcFun(
         ) -> int:
             return xorOut ^ fun(data, xorOut ^ crc, table)
 
-    return crcfun, tableList
+    return crcfun, tablelist
 
 
 # -----------------------------------------------------------------------------

--- a/src/crcmod/predefined.py
+++ b/src/crcmod/predefined.py
@@ -32,11 +32,10 @@ crcmod.predefined.Crc is an alias for crcmod.predefined.PredefinedCrc
 But if doing 'from crc.predefined import *', only PredefinedCrc is imported.
 """
 
+from typing import TypedDict
+
 # local imports
-import crcmod
-
-from typing import Any, Dict, List, Tuple
-
+from . import crcmod
 from .types import CrcFun
 
 __all__ = (
@@ -47,14 +46,20 @@ __all__ = (
 REVERSE = True
 NON_REVERSE = False
 
-# TODO(ntamas): migrate to TypedDict when we drop support for Python 3.7
-Definition = Dict[str, Any]
+class Definition(TypedDict):
+    name: str
+    identifier: str
+    poly: int
+    reverse: bool
+    init: int
+    xor_out: int
+    check: int
 
 # The following table defines the parameters of well-known CRC algorithms.
 # The "Check" value is the CRC for the ASCII byte sequence b"123456789". It
 # can be used for unit tests.
 # fmt: off
-_crc_definitions_table: List[Tuple[str, str, int, bool, int, int, int]] = [
+_crc_definitions_table: list[tuple[str, str, int, bool, int, int, int]] = [
 #       Name                Identifier-name,    Poly            Reverse         Init-value      XOR-out     Check
     (   'crc-8',            'Crc8',             0x107,          NON_REVERSE,    0x00,           0x00,       0xF4,       ),
     (   'crc-8-darc',       'Crc8Darc',         0x139,          REVERSE,        0x00,           0x00,       0x15,       ),
@@ -127,11 +132,11 @@ def _simplify_name(name: str) -> str:
     return name
 
 
-_crc_definitions_by_name: Dict[str, Definition] = {}
-_crc_definitions_by_identifier: Dict[str, Definition] = {}
-_crc_definitions: List[Definition] = []
+_crc_definitions_by_name: dict[str, Definition] = {}
+_crc_definitions_by_identifier: dict[str, Definition] = {}
+_crc_definitions: list[Definition] = []
 
-_crc_table_headings: List[str] = [
+_crc_table_headings: list[str] = [
     "name",
     "identifier",
     "poly",
@@ -141,14 +146,17 @@ _crc_table_headings: List[str] = [
     "check",
 ]
 
-for table_entry in _crc_definitions_table:
-    crc_definition: Definition = dict(zip(_crc_table_headings, table_entry))
+for name_str, identifier, poly, reverse, init, xor_out, check in _crc_definitions_table:
+    crc_definition = Definition(
+        name=name_str, identifier=identifier, poly=poly,
+        reverse=reverse, init=init, xor_out=xor_out, check=check,
+    )
     _crc_definitions.append(crc_definition)
-    name = _simplify_name(table_entry[0])
+    name = _simplify_name(name_str)
     if name in _crc_definitions_by_name:
         raise Exception("Duplicate entry for '{0}' in CRC table".format(name))
     _crc_definitions_by_name[name] = crc_definition
-    _crc_definitions_by_identifier[table_entry[1]] = crc_definition
+    _crc_definitions_by_identifier[identifier] = crc_definition
 
 
 def _get_definition_by_name(crc_name: str) -> Definition:

--- a/src/crcmod/types.py
+++ b/src/crcmod/types.py
@@ -29,7 +29,7 @@ from typing import Protocol
 __all__ = ("Buffer",)
 
 
-Buffer = Union[str, bytes, bytearray, memoryview, array[int]]
+Buffer = Union[str, bytes, bytearray, memoryview, "array[int]"]
 """Type alias for objects supported by the CRC functions as inputs."""
 
 

--- a/src/crcmod/types.py
+++ b/src/crcmod/types.py
@@ -21,17 +21,15 @@
 # -----------------------------------------------------------------------------
 
 from array import array
-from typing import Callable, Sequence, Union
+from typing import Callable, Union
+from collections.abc import Sequence
 
-try:
-    from typing import Protocol
-except ImportError:
-    from typing_extensions import Protocol  # type: ignore
+from typing import Protocol
 
 __all__ = ("Buffer",)
 
 
-Buffer = Union[str, bytes, bytearray, memoryview, array]
+Buffer = Union[str, bytes, bytearray, memoryview, array[int]]
 """Type alias for objects supported by the CRC functions as inputs."""
 
 


### PR DESCRIPTION
Thanks for modernizing this package for Python 3!

Since the minimum supported version is 3.9, this PR:
* Uses types from generic collections [PEP585](https://peps.python.org/pep-0585/) - e.g. `dict` instead of `typing.Dict`
* Uses `TypedDict`
* Adds a ruff/pyupgrade rule [`UP`](https://docs.astral.sh/ruff/rules/#pyupgrade-up) to lint this automatically
* Uses a couple relative/local imports to make my type-checker have an easier time of things (I didn't touch the C code)